### PR TITLE
Remove Incorrect Language Settings to Allow Default Locale Usage

### DIFF
--- a/src/Filament/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/src/Filament/Resources/CategoryResource/Pages/CreateCategory.php
@@ -12,14 +12,6 @@ class CreateCategory extends CreateRecord
 
     protected static string $resource = CategoryResource::class;
 
-    #[Reactive]
-    public ?string $activeLocale = null;
-
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
     protected function getHeaderActions(): array
     {
         return [

--- a/src/Filament/Resources/CategoryResource/Pages/EditCategory.php
+++ b/src/Filament/Resources/CategoryResource/Pages/EditCategory.php
@@ -12,14 +12,6 @@ class EditCategory extends EditRecord
 
     protected static string $resource = CategoryResource::class;
 
-    #[Reactive]
-    public ?string $activeLocale = null;
-
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
 
     protected function getHeaderActions(): array
     {

--- a/src/Filament/Resources/CategoryResource/Pages/ListCategories.php
+++ b/src/Filament/Resources/CategoryResource/Pages/ListCategories.php
@@ -13,15 +13,6 @@ class ListCategories extends ListRecords
     protected static string $resource = CategoryResource::class;
 
 
-    #[Reactive]
-    public ?string $activeLocale = null;
-
-    public static function getTranslatableLocales(): array
-    {
-        return ['en', 'ar'];
-    }
-
-
     protected function getHeaderActions(): array
     {
         return [


### PR DESCRIPTION
https://github.com/tomatophp/filament-cms/issues/14

This PR removes incorrect language settings in the following files, which were preventing the package from using the default language settings:

- src/Filament/Resources/CategoryResource/Pages/CreateCategory.php
- src/Filament/Resources/CategoryResource/Pages/EditCategory.php
- src/Filament/Resources/CategoryResource/Pages/ViewCategory.php

The following code was causing issues by overriding the default locale settings:

```
#[Reactive]
    public ?string $activeLocale = null;

    public static function getTranslatableLocales(): array
    {
        return ['en', 'ar'];
    }
```

By removing this code, the package can now properly utilize the default language settings as intended.

Related Issue:
This PR resolves the issue identified in [Issue #14](https://github.com/tomatophp/filament-cms/issues/14), where the package was unable to use the default language settings due to hardcoded locale configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed deprecated localization properties and methods from category management pages to streamline functionality.
  
- **Refactor**
	- Simplified the `CreateCategory`, `EditCategory`, and `ListCategories` classes by eliminating unnecessary localization elements, improving code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->