### PR TITLE
 Remove Redundant Index on slug Column in Migrations

### DIFF
--- a/database/migrations/2021_11_23_130725_create_categories_table.php
+++ b/database/migrations/2021_11_23_130725_create_categories_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                 $table->string('for')->default('posts')->nullable();
                 $table->string('type')->default('category')->nullable();
                 $table->json('name');
-                $table->string('slug')->unique()->index();
+                $table->string('slug')->unique();
                 $table->json('description')->nullable();
                 $table->string('icon')->nullable();
                 $table->string('color')->nullable();

--- a/database/migrations/2021_11_23_130847_create_posts_table.php
+++ b/database/migrations/2021_11_23_130847_create_posts_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
 
                 //Info
                 $table->json('title');
-                $table->string('slug')->unique()->index();
+                $table->string('slug')->unique();
 
                 $table->json('short_description')->nullable();
                 $table->json('keywords')->nullable();

--- a/database/migrations/2023_08_15_110333_create_tickets_table.php
+++ b/database/migrations/2023_08_15_110333_create_tickets_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
 
                 //Add User For Tickets
                 $table->string('subject');
-                $table->string('code')->unique()->index();
+                $table->string('code')->unique();
 
                 $table->longText('message')->nullable();
 


### PR DESCRIPTION
This PR improves the Laravel migration by removing the unnecessary index() call on the slug column.
Changes:
```php
$table->string('slug')->unique()->index();
```
Updated to:
```php
$table->string('slug')->unique();
```

Since unique() already creates an index, the extra index() is unnecessary.

Why this PR?

- Avoids redundant database indexes and keeps migrations clean.
- Prevents unnecessary queries when generating schema.
- Follows Laravel best practices for database optimization.

Refer Blogs
[https://laravel.com/docs/11.x/migrations#creating-indexes](https://laravel.com/docs/11.x/migrations#creating-indexes)

[https://stackoverflow.com/questions/9764120/does-a-unique-constraint-automatically-create-an-index-on-the-fields](https://stackoverflow.com/questions/9764120/does-a-unique-constraint-automatically-create-an-index-on-the-fields)

[https://stackoverflow.com/questions/49127291/how-to-create-unique-indexes-in-laravel/79395771#79395771](https://stackoverflow.com/questions/49127291/how-to-create-unique-indexes-in-laravel/79395771#79395771)


@3x1io 